### PR TITLE
Use libsdl2-dev from ubuntu instead of PPA on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,4 @@ rust:
     - stable
 before_install:
   - sudo apt-get install -y libsdl2-dev
+cache: cargo

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
+dist: xenial
 language: rust
 rust:
     - stable
 before_install:
-  - sudo add-apt-repository ppa:team-xbmc/ppa -y
-  - sudo apt-get -qq update
   - sudo apt-get install -y libsdl2-dev


### PR DESCRIPTION
`team-xbmc` no longer has libsdl packages, so [builds fail](https://travis-ci.org/pacmancoder/rustzx/builds/516848074).

Latest Ubuntu LTS version, "Xenial", has [quite recent sdl version](https://packages.ubuntu.com/xenial/libsdl2-dev), 2.0.4, while [latest available is 2.0.9](https://www.libsdl.org/download-2.0.php).

This build fails because `rustc-serialize` dependency no longer builds on recent rust compilers. It's fixed in #33.