### PR TITLE
Explain 48k vs 128k for --ay in --help

### DIFF
--- a/src/settings.rs
+++ b/src/settings.rs
@@ -105,7 +105,8 @@ impl RustzxSettings {
                                 .value_name("AY_TYPE")
                                 .possible_values(&["none", "mono", "abc", "acb"])
                                 .help("Selects AY mode. Use none to disable. \
-                                       For stereo features use abc or acb, default is mono."))
+                                       For stereo features use abc or acb, default is mono for \
+                                       128k and none for 48k."))
                       .arg(Arg::with_name("VOLUME")
                                 .long("volume")
                                 .value_name("VOLUME_VALUE")


### PR DESCRIPTION
#37 

Added explanation in `--help` that AY is disabled by default for 48k instead of being in "mono" mode.