### PR TITLE
Remove deprecated "time" crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,15 +41,6 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "kernel32-sys"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "lazy_static"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -146,7 +137,6 @@ dependencies = [
  "clap 2.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "sdl2 0.21.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -184,16 +174,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "time"
-version = "0.1.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "unicode-width"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -203,16 +183,6 @@ name = "vec_map"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
-[[package]]
-name = "winapi"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "winapi-build"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
 [metadata]
 "checksum ansi_term 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)" = "30275ad0ad84ec1c06dde3b3f7d23c6006b7d76d61a85e7060b426b747eff70d"
 "checksum ayumi 0.1.2 (git+https://github.com/pacmancoder/rust-ayumi.git)" = "<none>"
@@ -220,7 +190,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum bitflags 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "72cd7314bd4ee024071241147222c706e80385a1605ac7d4cd2fcc339da2ae46"
 "checksum clap 2.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4cbebe3ce784f9c63d83684d07cf2da470b88bb149ac17dc262b3062e6fe8d93"
 "checksum gcc 0.3.31 (registry+https://github.com/rust-lang/crates.io-index)" = "cfe877476e53690ebb0ce7325d0bf43e198d9500291b54b3c65e518de5039b07"
-"checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum lazy_static 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "49247ec2a285bb3dcb23cbd9c35193c025e7251bfce77c1d5da97e6362dffe7f"
 "checksum libc 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)" = "39dfaaa0f4da0f1a06876c5d94329d739ad0150868069cc235f1ddf80a0480e7"
 "checksum num 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)" = "d2ee34a0338c16ae67afb55824aaf8852700eb0f77ccd977807ccb7606b295f6"
@@ -236,8 +205,5 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum sdl2-sys 0.21.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a528c3e8a3f37a92d1131c34fb31a10004cebaaba72fb003e4e71ba38ce5e8fd"
 "checksum strsim 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0d5f575d5ced6634a5c4cb842163dab907dc7e9148b28dc482d81b8855cbe985"
 "checksum term_size 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a6a7c9a4de31e5622ec38533988a9e965aab09b26ee8bd7b8b0f56d488c3784d"
-"checksum time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)" = "3c7ec6d62a20df54e07ab3b78b9a3932972f4b7981de295563686849eb3989af"
 "checksum unicode-width 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2d6722facc10989f63ee0e20a83cd4e1714a9ae11529403ac7e0afd069abc39e"
 "checksum vec_map 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cac5efe5cb0fa14ec2f84f83c701c562ee63f6dcc680861b21d65c682adfb05f"
-"checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
-"checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ keywords = ["emulator", "game", "z80"]
 license = "MIT"
 
 [dependencies]
-time = "0.1"
 sdl2 = "0.21"
 lazy_static = "0.2"
 clap = "2.9"

--- a/src/app/rustzx.rs
+++ b/src/app/rustzx.rs
@@ -13,7 +13,7 @@ use emulator::*;
 
 
 /// max 100 ms interval in `max frames` speed mode
-const MAX_FRAME_TIME_NS: u64 = 100 * 1000000;
+const MAX_FRAME_TIME: Duration = Duration::from_millis(100);
 
 /// converts nanoseconds  to miliseconds
 fn ns_to_ms(ns: u64) -> f64 {
@@ -74,7 +74,7 @@ impl RustzxApp {
             // absolute start time
             let frame_start = Instant::now();
             // Emulate all requested frames
-            let cpu_dt_ns = self.emulator.emulate_frames(MAX_FRAME_TIME_NS);
+            let cpu_dt_ns = self.emulator.emulate_frames(MAX_FRAME_TIME);
             // if sound enabled sound ganeration allowed then move samples to sound thread
             if let Some(ref mut snd) = self.snd {
                 // if can be turned off even on speed change, so check it everytime
@@ -152,8 +152,8 @@ impl RustzxApp {
             // change window header
             if debug {
                 self.video.set_title(&format!("CPU: {:7.3}ms; FRAME:{:7.3}ms",
-                                               ns_to_ms(cpu_dt_ns),
-                                               frame_dt.subsec_millis()));
+                                               cpu_dt_ns.as_millis(),
+                                               frame_dt.as_millis()));
             }
         }
     }

--- a/src/app/rustzx.rs
+++ b/src/app/rustzx.rs
@@ -74,7 +74,7 @@ impl RustzxApp {
             // absolute start time
             let frame_start = Instant::now();
             // Emulate all requested frames
-            let cpu_dt_ns = self.emulator.emulate_frames(MAX_FRAME_TIME);
+            let cpu_dt = self.emulator.emulate_frames(MAX_FRAME_TIME);
             // if sound enabled sound ganeration allowed then move samples to sound thread
             if let Some(ref mut snd) = self.snd {
                 // if can be turned off even on speed change, so check it everytime
@@ -152,7 +152,7 @@ impl RustzxApp {
             // change window header
             if debug {
                 self.video.set_title(&format!("CPU: {:7.3}ms; FRAME:{:7.3}ms",
-                                               cpu_dt_ns.as_millis(),
+                                               cpu_dt.as_millis(),
                                                frame_dt.as_millis()));
             }
         }

--- a/src/emulator/mod.rs
+++ b/src/emulator/mod.rs
@@ -1,6 +1,5 @@
 //! Platform-independent high-level Emulator interaction module
-use time;
-
+use std::time::Instant;
 use utils::*;
 use z80::*;
 use zx::ZXController;
@@ -109,7 +108,7 @@ impl Emulator {
         let mut time = 0u64;
         'frame: loop {
             // start of current frame
-            let start_time = time::precise_time_ns();
+            let start_time = Instant::now();
             // reset controller internal frame counter
             self.controller.reset_frame_counter();
             'cpu: loop {
@@ -124,7 +123,7 @@ impl Emulator {
                     if self.controller.frames_count() >= multiplier {
                         // no more frames
                         self.controller.clear_events();
-                        return time::precise_time_ns() - start_time;
+                        return start_time.elapsed().as_nanos() as u64;
                     };
                     // if speed is maximal.
                 } else {
@@ -134,7 +133,7 @@ impl Emulator {
                     }
                 }
             }
-            time += time::precise_time_ns() - start_time;
+            time += start_time.elapsed().as_nanos() as u64;
             // if time is bigger than `max_time` then stop emulation cycle
             if time > max_time {
                 break 'frame;

--- a/src/emulator/mod.rs
+++ b/src/emulator/mod.rs
@@ -1,5 +1,5 @@
 //! Platform-independent high-level Emulator interaction module
-use std::time::Instant;
+use std::time::{Instant, Duration};
 use utils::*;
 use z80::*;
 use zx::ZXController;
@@ -104,8 +104,8 @@ impl Emulator {
     /// Emulate frames, maximum in `max_time` time, returns emulation time in nanoseconds
     /// in most cases time is max 1/50 of second, even when using
     /// loader acceleration
-    pub fn emulate_frames(&mut self, max_time: u64) -> u64 {
-        let mut time = 0u64;
+    pub fn emulate_frames(&mut self, max_time: Duration) -> Duration {
+        let mut time = Duration::new(0, 0);
         'frame: loop {
             // start of current frame
             let start_time = Instant::now();
@@ -123,7 +123,7 @@ impl Emulator {
                     if self.controller.frames_count() >= multiplier {
                         // no more frames
                         self.controller.clear_events();
-                        return start_time.elapsed().as_nanos() as u64;
+                        return start_time.elapsed();
                     };
                     // if speed is maximal.
                 } else {
@@ -133,7 +133,7 @@ impl Emulator {
                     }
                 }
             }
-            time += start_time.elapsed().as_nanos() as u64;
+            time += start_time.elapsed();
             // if time is bigger than `max_time` then stop emulation cycle
             if time > max_time {
                 break 'frame;

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,8 +26,6 @@
 //! View full License text in file `LICENSE.md`
 #![allow(dead_code)]
 
-/// time lib for frame timings
-extern crate time;
 /// Lazy static for macine specs
 #[macro_use]
 extern crate lazy_static;


### PR DESCRIPTION
Removed [`time`](https://github.com/rust-lang-deprecated/time) crate, which is deprecated, replaced `time::precise_time_ns` with standard library's `std::time::Instant`.

I'm not sure if it worsened "smoothness" of emulation. It feels the same after this change. I'm not sure that `std::time::Instant` is as precise as `time::precise_time_ns` on most systems. However, it all boils down to `thread::sleep`, which can't be very precise, I think, due to nature of schedulers in standard non-realtime OSes, so nanosecond-grade precision for time measurements is probably not as important.

To get feeling how `std::time::Instant` works, I ran the following script:

```rust
use std::time::Instant;

fn main() {
    let mut t = Instant::now();
    loop {
        println!("{:?}", t.elapsed());
        t = Instant::now();
    }
}
```

It outputs something like this:

```
73ns
41ns
41ns
75ns
42ns
42ns
76ns
43ns
41ns
74ns
44ns
44ns
75ns
41ns
42ns
77ns
41ns
41ns
```

So probably quite precise on my system (Mac OS). Not tested on Linux and Windows.