### PR TITLE
Use PathBuf/Path/AsRef<Path> for filenames in various places

### DIFF
--- a/src/emulator/loaders/mod.rs
+++ b/src/emulator/loaders/mod.rs
@@ -19,20 +19,10 @@ pub fn load_file_autodetect(emulator: &mut Emulator, file: impl AsRef<Path>) {
         .map(|s| s.to_lowercase());
     match extension {
         Some(ref s) if s == "sna" => {
-            // TODO: load_sna should take Path for filename
-            match file.as_ref().to_str() {
-                Some(file_str) => load_sna(emulator, file_str),
-                None => (),
-            }
+            load_sna(emulator, file)
         }
         Some(ref s) if s == "tap" => {
-            // TODO: insert should take Path for filename
-            match file.as_ref().to_str() {
-                Some(file_str) => {
-                    emulator.controller.tape.insert(file_str);
-                }
-                None => (),
-            }
+            emulator.controller.tape.insert(file.as_ref());
         }
         _ => (),
     }

--- a/src/emulator/loaders/sna.rs
+++ b/src/emulator/loaders/sna.rs
@@ -1,6 +1,7 @@
 // std
 use std::io::Read;
 use std::fs::File;
+use std::path::Path;
 // emulator
 use emulator::Emulator;
 use z80::opcodes::execute_pop_16;
@@ -9,7 +10,7 @@ use utils::{Clocks, make_word};
 use zx::colors::ZXColor;
 
 /// SNA snapshot loading function
-pub fn load_sna(emulator: &mut Emulator, file: &str) {
+pub fn load_sna(emulator: &mut Emulator, file: impl AsRef<Path>) {
     let mut data = Vec::new();
     File::open(file).unwrap().read_to_end(&mut data).unwrap();
     assert!(data.len() == 49179);

--- a/src/emulator/mod.rs
+++ b/src/emulator/mod.rs
@@ -75,7 +75,7 @@ impl Emulator {
     }
 
     /// loads snapshot file
-    pub fn load_sna(&mut self, file: &str) {
+    pub fn load_sna(&mut self, file: impl AsRef<Path>) {
         loaders::load_sna(self, file)
     }
 

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,4 +1,4 @@
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use clap::{Arg, App, AppSettings};
 use zx::machine::ZXMachine;
 use zx::sound::ay::ZXAYMode;
@@ -20,9 +20,9 @@ pub struct RustzxSettings {
     pub sound_enabled: bool,
     pub volume: usize,
     pub latency: usize,
-    pub rom: Option<String>,
-    pub tap: Option<String>,
-    pub sna: Option<String>,
+    pub rom: Option<PathBuf>,
+    pub tap: Option<PathBuf>,
+    pub sna: Option<PathBuf>,
 }
 
 impl RustzxSettings {
@@ -141,26 +141,26 @@ impl RustzxSettings {
            .beeper(!cmd.is_present("NOBEEPER"))
            .sound(!cmd.is_present("NOSOUND"))
            .kempston(cmd.is_present("KEMPSTON"));
-        if let Some(path) = cmd.value_of("ROM") {
+        if let Some(path) = cmd.value_of_os("ROM") {
             if Path::new(path).is_file() {
                 out.rom(path);
             } else {
-                println!("[Warning] ROM file \"{}\" not found", path);
+                println!("[Warning] ROM file \"{}\" not found", path.to_string_lossy());
             }
         }
-        if let Some(path) = cmd.value_of("TAP") {
+        if let Some(path) = cmd.value_of_os("TAP") {
             if Path::new(path).is_file() {
                 out.tap(path);
             } else {
-                println!("[Warning] Tape file \"{}\" not found", path);
+                println!("[Warning] Tape file \"{}\" not found", path.to_string_lossy());
             }
         }
-        if let Some(path) = cmd.value_of("SNA") {
+        if let Some(path) = cmd.value_of_os("SNA") {
             if out.machine == ZXMachine::Sinclair48K {
                 if Path::new(path).is_file() {
                     out.sna(path);
                 } else {
-                    println!("[Warning] Snapshot file \"{}\" not found", path);
+                    println!("[Warning] Snapshot file \"{}\" not found", path.to_string_lossy());
                 }
             } else {
                 println!("[Warning] 128K SNA is not supported!");
@@ -256,18 +256,18 @@ impl RustzxSettings {
         self
     }
     /// changes TAP path
-    pub fn tap(&mut self, value: &str) -> &mut Self {
-        self.tap = Some(value.to_owned());
+    pub fn tap(&mut self, value: impl AsRef<Path>) -> &mut Self {
+        self.tap = Some(value.as_ref().into());
         self
     }
     /// changes SNA path
-    pub fn sna(&mut self, value: &str) -> &mut Self {
-        self.sna = Some(value.to_owned());
+    pub fn sna(&mut self, value: impl AsRef<Path>) -> &mut Self {
+        self.sna = Some(value.as_ref().into());
         self
     }
     /// changes ROM path
-    pub fn rom(&mut self, value: &str) -> &mut Self {
-        self.rom = Some(value.to_owned());
+    pub fn rom(&mut self, value: impl AsRef<Path>) -> &mut Self {
+        self.rom = Some(value.as_ref().into());
         self
     }
     /// changes emulation speed

--- a/src/zx/tape/mod.rs
+++ b/src/zx/tape/mod.rs
@@ -4,6 +4,7 @@ mod tap;
 // reexport Tap Tape player
 pub use self::tap::Tap;
 
+use std::path::Path;
 use utils::Clocks;
 
 /// Result of tape insertion,
@@ -34,7 +35,7 @@ pub trait ZXTape {
     /// Makes procession of type in definite time
     fn process_clocks(&mut self, clocks: Clocks);
     /// insert new media
-    fn insert(&mut self, path: &str) -> InsertResult;
+    fn insert(&mut self, path: &Path) -> InsertResult;
     /// ejects tape
     fn eject(&mut self);
     /// stops tape

--- a/src/zx/tape/tap.rs
+++ b/src/zx/tape/tap.rs
@@ -129,7 +129,7 @@ impl ZXTape for Tap {
     }
 
     /// updates internal structure according new tape file
-    fn insert(&mut self, path: &str) -> InsertResult {
+    fn insert(&mut self, path: &Path) -> InsertResult {
         if let Ok(mut file) = File::open(path) {
             if let Err(_) = file.read_to_end(&mut self.data) {
                 return InsertResult::Err("TAP file read error");


### PR DESCRIPTION
Changed `String`/`&str` representation of filenames/paths to more idiomatic `Pathbuf` and `Path` in various places.

As [`std::path`](https://doc.rust-lang.org/std/path/index.html) types are wrappers around [`OsString`](https://doc.rust-lang.org/std/ffi/struct.OsString.html), non-utf8 filenames are now supported. Changed command-line handling to allow that on `--tap`, `--sna`, `--rom`.