### PR TITLE
Apply rustfmt formatting

### DIFF
--- a/src/app/events/events_sdl.rs
+++ b/src/app/events/events_sdl.rs
@@ -1,13 +1,13 @@
 //! Real events SDL backend
-use super::{EventDevice, Event};
+use super::{Event, EventDevice};
 use backends::SDL_CONTEXT;
 use sdl2::event::Event as SdlEvent;
-use sdl2::EventPump;
 use sdl2::keyboard::Scancode;
+use sdl2::EventPump;
 use settings::RustzxSettings;
 use utils::EmulationSpeed;
-use zx::keys::*;
 use zx::joy::kempston::KempstonKey;
+use zx::keys::*;
 
 /// Represents SDL Envets bakend
 pub struct EventsSdl {
@@ -24,9 +24,7 @@ impl EventsSdl {
             pump = sdl.borrow_mut().event_pump().ok();
         });
         if let Some(pump) = pump {
-            EventsSdl {
-                event_pump: pump,
-            }
+            EventsSdl { event_pump: pump }
         } else {
             panic!("[ERROR] Sdl event pump init error");
         }
@@ -114,13 +112,13 @@ impl EventDevice for EventsSdl {
             // if event found
             match event {
                 // exot requested
-                SdlEvent::Quit {..} => Some(Event::Exit),
+                SdlEvent::Quit { .. } => Some(Event::Exit),
                 // if any key pressed
-                action @ SdlEvent::KeyDown {..} | action @ SdlEvent::KeyUp {..} => {
+                action @ SdlEvent::KeyDown { .. } | action @ SdlEvent::KeyUp { .. } => {
                     // assemble tuple from scancode and its state
                     let (scancode, state) = match action {
-                        SdlEvent::KeyDown {scancode: code, ..} => (code, true),
-                        SdlEvent::KeyUp {scancode: code, ..} => (code, false),
+                        SdlEvent::KeyDown { scancode: code, .. } => (code, true),
+                        SdlEvent::KeyUp { scancode: code, .. } => (code, false),
                         _ => unreachable!(),
                     };
                     if let Some(key) = self.scancode_to_zxkey(scancode) {
@@ -141,21 +139,13 @@ impl EventDevice for EventsSdl {
                                     Scancode::F4 => {
                                         Some(Event::ChangeSpeed(EmulationSpeed::Definite(2)))
                                     }
-                                    Scancode::F5 => {
-                                        Some(Event::ChangeSpeed(EmulationSpeed::Max))
-                                    }
+                                    Scancode::F5 => Some(Event::ChangeSpeed(EmulationSpeed::Max)),
                                     // debug info control
-                                    Scancode::F6 => {
-                                        Some(Event::SwitchDebug)
-                                    }
+                                    Scancode::F6 => Some(Event::SwitchDebug),
                                     // tape control
-                                    Scancode::Insert => {
-                                        Some(Event::InsertTape)
-                                    }
-                                    Scancode::Delete => {
-                                        Some(Event::StopTape)
-                                    }
-                                    _ => None
+                                    Scancode::Insert => Some(Event::InsertTape),
+                                    Scancode::Delete => Some(Event::StopTape),
+                                    _ => None,
                                 }
                             } else {
                                 None
@@ -164,10 +154,8 @@ impl EventDevice for EventsSdl {
                             None
                         }
                     }
-                },
-                SdlEvent::DropFile {filename, ..} => {
-                    Some(Event::OpenFile(filename.into()))
-                },
+                }
+                SdlEvent::DropFile { filename, .. } => Some(Event::OpenFile(filename.into())),
                 _ => None,
             }
         } else {

--- a/src/app/events/mod.rs
+++ b/src/app/events/mod.rs
@@ -5,8 +5,8 @@ pub use self::events_sdl::EventsSdl;
 
 use std::path::PathBuf;
 use utils::EmulationSpeed;
-use zx::keys::*;
 use zx::joy::kempston::KempstonKey;
+use zx::keys::*;
 
 // Event type
 pub enum Event {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1,7 +1,7 @@
 //! This module provides main application class.
-mod rustzx;
-mod video;
-mod sound;
 mod events;
+mod rustzx;
+mod sound;
+mod video;
 // main re-export
 pub use self::rustzx::RustzxApp;

--- a/src/app/rustzx.rs
+++ b/src/app/rustzx.rs
@@ -2,15 +2,14 @@
 //! Handles all platform-related, hardware-related stuff
 //! and command-line interface
 
-use std::thread;
-use std::time::{Duration, Instant};
+use app::events::*;
 use app::sound::*;
 use app::video::*;
-use app::events::*;
-use zx::constants::*;
-use settings::RustzxSettings;
 use emulator::*;
-
+use settings::RustzxSettings;
+use std::thread;
+use std::time::{Duration, Instant};
+use zx::constants::*;
 
 /// max 100 ms interval in `max frames` speed mode
 const MAX_FRAME_TIME: Duration = Duration::from_millis(100);
@@ -89,20 +88,30 @@ impl RustzxApp {
                 }
             }
             // load new textures to sdl
-            self.video.update_texture(self.tex_border, self.emulator.controller.border.texture());
-            self.video.update_texture(self.tex_canvas, self.emulator.controller.canvas.texture());
+            self.video
+                .update_texture(self.tex_border, self.emulator.controller.border.texture());
+            self.video
+                .update_texture(self.tex_canvas, self.emulator.controller.canvas.texture());
             // rendering block
             self.video.begin();
-            self.video.draw_texture_2d(self.tex_border,
-                                       Some(Rect::new(0,
-                                                      0,
-                                                      SCREEN_WIDTH as u32 * scale,
-                                                      SCREEN_HEIGHT as u32 * scale)));
-            self.video.draw_texture_2d(self.tex_canvas,
-                                       Some(Rect::new(CANVAS_X as i32 * scale as i32,
-                                                      CANVAS_Y as i32 * scale as i32,
-                                                      CANVAS_WIDTH as u32 * scale,
-                                                      CANVAS_HEIGHT as u32 * scale)));
+            self.video.draw_texture_2d(
+                self.tex_border,
+                Some(Rect::new(
+                    0,
+                    0,
+                    SCREEN_WIDTH as u32 * scale,
+                    SCREEN_HEIGHT as u32 * scale,
+                )),
+            );
+            self.video.draw_texture_2d(
+                self.tex_canvas,
+                Some(Rect::new(
+                    CANVAS_X as i32 * scale as i32,
+                    CANVAS_Y as i32 * scale as i32,
+                    CANVAS_WIDTH as u32 * scale,
+                    CANVAS_HEIGHT as u32 * scale,
+                )),
+            );
             self.video.end();
             // check all events
             if let Some(event) = self.events.pop_event() {
@@ -116,8 +125,8 @@ impl RustzxApp {
                     Event::SwitchDebug => {
                         debug = !debug;
                         if !debug {
-                            self.video.set_title(&format!("RustZX v{}",
-                                                        env!("CARGO_PKG_VERSION")));
+                            self.video
+                                .set_title(&format!("RustZX v{}", env!("CARGO_PKG_VERSION")));
                         }
                     }
                     Event::ChangeSpeed(speed) => {
@@ -128,12 +137,8 @@ impl RustzxApp {
                             joy.key(key, state);
                         }
                     }
-                    Event::InsertTape => {
-                        self.emulator.controller.tape.play()
-                    }
-                    Event::StopTape => {
-                        self.emulator.controller.tape.stop()
-                    }
+                    Event::InsertTape => self.emulator.controller.tape.play(),
+                    Event::StopTape => self.emulator.controller.tape.stop(),
                     Event::OpenFile(path) => {
                         self.emulator.load_file_autodetect(path);
                     }
@@ -142,11 +147,7 @@ impl RustzxApp {
             // how long emulation iteration was
             let emulation_dt = frame_start.elapsed();
             if emulation_dt < frame_target_dt {
-                let wait_koef = if self.emulator.have_sound() {
-                    9
-                } else {
-                    10
-                };
+                let wait_koef = if self.emulator.have_sound() { 9 } else { 10 };
                 // sleep untill frame sync
                 thread::sleep((frame_target_dt - emulation_dt) * wait_koef / 10);
             };
@@ -154,9 +155,11 @@ impl RustzxApp {
             let frame_dt = frame_start.elapsed();
             // change window header
             if debug {
-                self.video.set_title(&format!("CPU: {:7.3}ms; FRAME:{:7.3}ms",
-                                               cpu_dt.as_millis(),
-                                               frame_dt.as_millis()));
+                self.video.set_title(&format!(
+                    "CPU: {:7.3}ms; FRAME:{:7.3}ms",
+                    cpu_dt.as_millis(),
+                    frame_dt.as_millis()
+                ));
             }
         }
     }

--- a/src/app/sound/sound_sdl.rs
+++ b/src/app/sound/sound_sdl.rs
@@ -1,14 +1,14 @@
 //! Real Audio SDL backend
 use super::{SoundDevice, ZXSample};
-use std::sync::mpsc::{sync_channel, Receiver, SyncSender};
-use sdl2::audio::{AudioCallback, AudioSpecDesired, AudioDevice};
-use zx::sound::{CHANNELS, SAMPLE_RATE};
 use backends::SDL_CONTEXT;
+use sdl2::audio::{AudioCallback, AudioDevice, AudioSpecDesired};
 use settings::RustzxSettings;
+use std::sync::mpsc::{sync_channel, Receiver, SyncSender};
+use zx::sound::{CHANNELS, SAMPLE_RATE};
 
 /// Struct which used in SDL audio callback
 struct SdlCallback {
-    samples: Receiver<ZXSample>
+    samples: Receiver<ZXSample>,
 }
 
 impl AudioCallback for SdlCallback {
@@ -47,11 +47,9 @@ impl SoundSdl {
                 samples: Some(settings.latency as u16),
             };
             let (tx, rx) = sync_channel(settings.latency as usize);
-            let device_handle = audio.open_playback(None, &desired_spec, |_| {
-                SdlCallback {
-                    samples: rx,
-                }
-            }).expect("[ERROR Sdl audio device error, try --nosound]");
+            let device_handle = audio
+                .open_playback(None, &desired_spec, |_| SdlCallback { samples: rx })
+                .expect("[ERROR Sdl audio device error, try --nosound]");
             // run
             device_handle.resume();
             // save device and cahnnel handles

--- a/src/app/video/mod.rs
+++ b/src/app/video/mod.rs
@@ -21,7 +21,7 @@ pub struct Rect {
 
 impl Rect {
     /// Constructs new rect
-    pub fn new(x: i32, y:i32, w: u32, h: u32) -> Rect {
+    pub fn new(x: i32, y: i32, w: u32, h: u32) -> Rect {
         Rect {
             x: x,
             y: y,

--- a/src/emulator/loaders/mod.rs
+++ b/src/emulator/loaders/mod.rs
@@ -18,9 +18,7 @@ pub fn load_file_autodetect(emulator: &mut Emulator, file: impl AsRef<Path>) {
         .and_then(|os_str| os_str.to_str())
         .map(|s| s.to_lowercase());
     match extension {
-        Some(ref s) if s == "sna" => {
-            load_sna(emulator, file)
-        }
+        Some(ref s) if s == "sna" => load_sna(emulator, file),
         Some(ref s) if s == "tap" => {
             emulator.controller.tape.insert(file.as_ref());
         }

--- a/src/emulator/loaders/sna.rs
+++ b/src/emulator/loaders/sna.rs
@@ -1,12 +1,12 @@
 // std
-use std::io::Read;
 use std::fs::File;
+use std::io::Read;
 use std::path::Path;
 // emulator
 use emulator::Emulator;
+use utils::{make_word, Clocks};
 use z80::opcodes::execute_pop_16;
 use z80::RegName16;
-use utils::{Clocks, make_word};
 use zx::colors::ZXColor;
 
 /// SNA snapshot loading function
@@ -43,15 +43,20 @@ pub fn load_sna(emulator: &mut Emulator, file: impl AsRef<Path>) {
     // interrupt mode
     emulator.cpu.set_im(data[25]);
     // set border
-    emulator.controller.border.set_border(Clocks(0), ZXColor::from_bits(data[26]));
+    emulator
+        .controller
+        .border
+        .set_border(Clocks(0), ZXColor::from_bits(data[26]));
     // ram pages
     emulator.controller.memory.load_ram(0, &data[27..16411]);
     // validate screen, it has been changed
     emulator.controller.memory.load_ram(1, &data[16411..32795]);
     emulator.controller.memory.load_ram(2, &data[32795..49179]);
     // RET
-    execute_pop_16(&mut emulator.cpu,
-                   &mut emulator.controller,
-                   RegName16::PC,
-                   Clocks(0));
+    execute_pop_16(
+        &mut emulator.cpu,
+        &mut emulator.controller,
+        RegName16::PC,
+        Clocks(0),
+    );
 }

--- a/src/emulator/loaders/tap.rs
+++ b/src/emulator/loaders/tap.rs
@@ -1,7 +1,7 @@
 // emulator
 use emulator::Emulator;
+use utils::{make_word, Clocks};
 use z80::*;
-use utils::{Clocks, make_word};
 
 pub fn fast_load_tap(emulator: &mut Emulator) {
     // resetting tape pos to beginning.
@@ -56,7 +56,7 @@ pub fn fast_load_tap(emulator: &mut Emulator) {
             // LOAD
             if (f & FLAG_CARRY) != 0 {
                 emulator.controller.write_internal(dest, current_byte);
-                // VERIFY
+            // VERIFY
             } else {
                 // check for parity each byte, if this fails - set flags to error state
                 acc = emulator.controller.memory.read(dest) ^ current_byte;
@@ -77,16 +77,21 @@ pub fn fast_load_tap(emulator: &mut Emulator) {
     // set regs to new state
     emulator.cpu.regs.set_reg_16(RegName16::IX, dest);
     emulator.cpu.regs.set_reg_16(RegName16::DE, length);
-    emulator.cpu.regs.set_hl(make_word(parity_acc, current_byte));
+    emulator
+        .cpu
+        .regs
+        .set_hl(make_word(parity_acc, current_byte));
     emulator.cpu.regs.set_acc(acc);
     // set new flag, if something changed
     if let Some(new_flags) = result_flags {
         f = new_flags;
         // RET
-        opcodes::execute_pop_16(&mut emulator.cpu,
-                                &mut emulator.controller,
-                                RegName16::PC,
-                                Clocks(0));
+        opcodes::execute_pop_16(
+            &mut emulator.cpu,
+            &mut emulator.controller,
+            RegName16::PC,
+            Clocks(0),
+        );
     }
     emulator.cpu.regs.set_flags(f);
     // move to next block

--- a/src/emulator/mod.rs
+++ b/src/emulator/mod.rs
@@ -1,10 +1,10 @@
 //! Platform-independent high-level Emulator interaction module
+use settings::RustzxSettings;
 use std::path::Path;
-use std::time::{Instant, Duration};
+use std::time::{Duration, Instant};
 use utils::*;
 use z80::*;
 use zx::ZXController;
-use settings::RustzxSettings;
 
 mod loaders;
 
@@ -133,7 +133,7 @@ impl Emulator {
                         self.controller.clear_events();
                         return start_time.elapsed();
                     };
-                    // if speed is maximal.
+                // if speed is maximal.
                 } else {
                     // if any frame passed then break cpu loop, but try to start new frame
                     if self.controller.frames_count() != 0 {

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,21 +29,21 @@
 /// Lazy static for macine specs
 #[macro_use]
 extern crate lazy_static;
+/// AY chip emulation library pacmancoder/rust-ayumi
+extern crate ayumi;
 /// Command line parser
 extern crate clap;
 /// backend => sound, video, events
 extern crate sdl2;
-/// AY chip emulation library pacmancoder/rust-ayumi
-extern crate ayumi;
 
 // crate consists of theese modules
+mod app;
+mod backends;
+mod emulator;
+mod settings;
 mod utils;
 mod z80;
 mod zx;
-mod app;
-mod emulator;
-mod backends;
-mod settings;
 
 use app::RustzxApp;
 use settings::RustzxSettings;

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,9 +1,9 @@
+use clap::{App, AppSettings, Arg};
 use std::path::{Path, PathBuf};
-use clap::{Arg, App, AppSettings};
+use utils::EmulationSpeed;
+use zx::constants::{SCREEN_HEIGHT, SCREEN_WIDTH};
 use zx::machine::ZXMachine;
 use zx::sound::ay::ZXAYMode;
-use zx::constants::{SCREEN_WIDTH, SCREEN_HEIGHT};
-use utils::EmulationSpeed;
 // TODO: move comand line parsing here
 
 /// Structure to handle all emulator runtime settings
@@ -51,76 +51,105 @@ impl RustzxSettings {
         let mut out = Self::new();
         // parse cli
         let cmd = App::new("rustzx")
-                      .setting(AppSettings::ColoredHelp)
-                      .version(env!("CARGO_PKG_VERSION"))
-                      .author("Vladislav Nikonov <pacmancoder@gmail.com>")
-                      .about("ZX Spectrum emulator written in pure Rust")
-                      // machine settings
-                      .arg(Arg::with_name("128K")
-                               .long("128k")
-                               .help("Enables ZX Spectrum 128K mode"))
-                      .arg(Arg::with_name("FASTLOAD")
-                               .short("f")
-                               .long("fastload")
-                               .help("Accelerates standard tape loaders"))
-                      // media files
-                      .arg(Arg::with_name("ROM")
-                               .long("rom")
-                               .value_name("ROM_PATH")
-                               .help("Selects path to rom, otherwise default will be used"))
-                      .arg(Arg::with_name("TAP")
-                               .long("tap")
-                               .value_name("TAP_PATH")
-                               .help("Selects path to *.tap file"))
-                      .arg(Arg::with_name("SNA")
-                               .long("sna")
-                               .value_name("SNA_PATH")
-                               .help("Selects path to *.sna snapshot file"))
-                      // devices
-                      .arg(Arg::with_name("KEMPSTON")
-                                .short("k")
-                                .long("kempston")
-                                .help("Enables Kempston joystick. Controlls via arrow keys and \
-                                       Alt buttons"))
-                      // emulator settings
-                      .arg(Arg::with_name("SPEED")
-                               .long("speed")
-                               .value_name("SPEED_VALUE")
-                               .help("Selects speed for emulator in integer multiplier form"))
-                      .arg(Arg::with_name("SCALE")
-                               .long("scale")
-                               .value_name("SCALE_VALUE")
-                               .help("Selects default screen size. possible values are positive \
-                                      integers. Default value is 2"))
-                      // sound
-                      .arg(Arg::with_name("NOSOUND")
-                               .long("nosound")
-                               .help("Disables sound. Use it when you have problems with audio \
-                                      playback"))
-                      .arg(Arg::with_name("NOBEEPER")
-                               .long("nobeeper")
-                               .help("Disables beeper"))
-                      .arg(Arg::with_name("AY")
-                                .long("ay")
-                                .value_name("AY_TYPE")
-                                .possible_values(&["none", "mono", "abc", "acb"])
-                                .help("Selects AY mode. Use none to disable. \
-                                       For stereo features use abc or acb, default is mono for \
-                                       128k and none for 48k."))
-                      .arg(Arg::with_name("VOLUME")
-                                .long("volume")
-                                .value_name("VOLUME_VALUE")
-                                .help("Selects volume - value in range 0..200. Volume over 100 \
-                                       can cause sound artifacts"))
-                      .arg(Arg::with_name("LATENCY")
-                                .long("latency")
-                                .short("l")
-                                .value_name("SAMPLES")
-                                .help("Selects audio latency. Default is 1024 samples. Set higher \
-                                       latency if emulator have sound glitches. Or if your \
-                                       machine can handle this - try to set it lower. Must be \
-                                       power of two."))
-                      .get_matches();
+            .setting(AppSettings::ColoredHelp)
+            .version(env!("CARGO_PKG_VERSION"))
+            .author("Vladislav Nikonov <pacmancoder@gmail.com>")
+            .about("ZX Spectrum emulator written in pure Rust")
+            // machine settings
+            .arg(
+                Arg::with_name("128K")
+                    .long("128k")
+                    .help("Enables ZX Spectrum 128K mode"),
+            )
+            .arg(
+                Arg::with_name("FASTLOAD")
+                    .short("f")
+                    .long("fastload")
+                    .help("Accelerates standard tape loaders"),
+            )
+            // media files
+            .arg(
+                Arg::with_name("ROM")
+                    .long("rom")
+                    .value_name("ROM_PATH")
+                    .help("Selects path to rom, otherwise default will be used"),
+            )
+            .arg(
+                Arg::with_name("TAP")
+                    .long("tap")
+                    .value_name("TAP_PATH")
+                    .help("Selects path to *.tap file"),
+            )
+            .arg(
+                Arg::with_name("SNA")
+                    .long("sna")
+                    .value_name("SNA_PATH")
+                    .help("Selects path to *.sna snapshot file"),
+            )
+            // devices
+            .arg(Arg::with_name("KEMPSTON").short("k").long("kempston").help(
+                "Enables Kempston joystick. Controlls via arrow keys and \
+                 Alt buttons",
+            ))
+            // emulator settings
+            .arg(
+                Arg::with_name("SPEED")
+                    .long("speed")
+                    .value_name("SPEED_VALUE")
+                    .help("Selects speed for emulator in integer multiplier form"),
+            )
+            .arg(
+                Arg::with_name("SCALE")
+                    .long("scale")
+                    .value_name("SCALE_VALUE")
+                    .help(
+                        "Selects default screen size. possible values are positive \
+                         integers. Default value is 2",
+                    ),
+            )
+            // sound
+            .arg(Arg::with_name("NOSOUND").long("nosound").help(
+                "Disables sound. Use it when you have problems with audio \
+                 playback",
+            ))
+            .arg(
+                Arg::with_name("NOBEEPER")
+                    .long("nobeeper")
+                    .help("Disables beeper"),
+            )
+            .arg(
+                Arg::with_name("AY")
+                    .long("ay")
+                    .value_name("AY_TYPE")
+                    .possible_values(&["none", "mono", "abc", "acb"])
+                    .help(
+                        "Selects AY mode. Use none to disable. \
+                         For stereo features use abc or acb, default is mono for \
+                         128k and none for 48k.",
+                    ),
+            )
+            .arg(
+                Arg::with_name("VOLUME")
+                    .long("volume")
+                    .value_name("VOLUME_VALUE")
+                    .help(
+                        "Selects volume - value in range 0..200. Volume over 100 \
+                         can cause sound artifacts",
+                    ),
+            )
+            .arg(
+                Arg::with_name("LATENCY")
+                    .long("latency")
+                    .short("l")
+                    .value_name("SAMPLES")
+                    .help(
+                        "Selects audio latency. Default is 1024 samples. Set higher \
+                         latency if emulator have sound glitches. Or if your \
+                         machine can handle this - try to set it lower. Must be \
+                         power of two.",
+                    ),
+            )
+            .get_matches();
         // machine type
         if cmd.is_present("128K") {
             out.machine(ZXMachine::Sinclair128K);
@@ -138,21 +167,27 @@ impl RustzxSettings {
             };
         }
         out.fastload(cmd.is_present("FASTLOAD"))
-           .beeper(!cmd.is_present("NOBEEPER"))
-           .sound(!cmd.is_present("NOSOUND"))
-           .kempston(cmd.is_present("KEMPSTON"));
+            .beeper(!cmd.is_present("NOBEEPER"))
+            .sound(!cmd.is_present("NOSOUND"))
+            .kempston(cmd.is_present("KEMPSTON"));
         if let Some(path) = cmd.value_of_os("ROM") {
             if Path::new(path).is_file() {
                 out.rom(path);
             } else {
-                println!("[Warning] ROM file \"{}\" not found", path.to_string_lossy());
+                println!(
+                    "[Warning] ROM file \"{}\" not found",
+                    path.to_string_lossy()
+                );
             }
         }
         if let Some(path) = cmd.value_of_os("TAP") {
             if Path::new(path).is_file() {
                 out.tap(path);
             } else {
-                println!("[Warning] Tape file \"{}\" not found", path.to_string_lossy());
+                println!(
+                    "[Warning] Tape file \"{}\" not found",
+                    path.to_string_lossy()
+                );
             }
         }
         if let Some(path) = cmd.value_of_os("SNA") {
@@ -160,20 +195,23 @@ impl RustzxSettings {
                 if Path::new(path).is_file() {
                     out.sna(path);
                 } else {
-                    println!("[Warning] Snapshot file \"{}\" not found", path.to_string_lossy());
+                    println!(
+                        "[Warning] Snapshot file \"{}\" not found",
+                        path.to_string_lossy()
+                    );
                 }
             } else {
                 println!("[Warning] 128K SNA is not supported!");
             }
         }
         if let Some(value) = cmd.value_of("AY") {
-           match value {
-               "none" => { out.ay(false) },
-               "mono" => { out.ay_mode(ZXAYMode::Mono) },
-               "abc" => { out.ay_mode(ZXAYMode::ABC) },
-               "acb" => { out.ay_mode(ZXAYMode::ACB) },
-               _ => unreachable!(),
-           };
+            match value {
+                "none" => out.ay(false),
+                "mono" => out.ay_mode(ZXAYMode::Mono),
+                "abc" => out.ay_mode(ZXAYMode::ABC),
+                "acb" => out.ay_mode(ZXAYMode::ACB),
+                _ => unreachable!(),
+            };
         };
         if let Some(value) = cmd.value_of("VOLUME") {
             if let Ok(value) = value.parse::<usize>() {
@@ -243,11 +281,7 @@ impl RustzxSettings {
 
     /// Changes volume
     pub fn volume(&mut self, val: usize) -> &mut Self {
-        self.volume = if val > 200 {
-            200
-        } else {
-            val
-        };
+        self.volume = if val > 200 { 200 } else { val };
         self
     }
     /// cahnges kempston joy connection

--- a/src/utils/clocks.rs
+++ b/src/utils/clocks.rs
@@ -1,5 +1,4 @@
-
-use std::ops::{AddAssign, Add, SubAssign, Sub};
+use std::ops::{Add, AddAssign, Sub, SubAssign};
 /// Clocks count
 /// It also have different Trait implementations
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd)]

--- a/src/utils/events.rs
+++ b/src/utils/events.rs
@@ -1,5 +1,5 @@
 use std::collections::VecDeque;
-use utils::{EmulationSpeed, Clocks};
+use utils::{Clocks, EmulationSpeed};
 
 /// Type of happened event
 pub enum EventKind {
@@ -32,7 +32,9 @@ pub struct EventQueue {
 impl EventQueue {
     /// cnstructs new EventQueue
     pub fn new() -> EventQueue {
-        EventQueue { deque: VecDeque::new() }
+        EventQueue {
+            deque: VecDeque::new(),
+        }
     }
     /// addd new event
     pub fn send_event(&mut self, e: Event) {

--- a/src/utils/instantflag.rs
+++ b/src/utils/instantflag.rs
@@ -8,7 +8,9 @@ pub struct InstantFlag {
 impl InstantFlag {
     /// constructs self from initial value
     pub fn new(value: bool) -> InstantFlag {
-        InstantFlag { f: Cell::new(value) }
+        InstantFlag {
+            f: Cell::new(value),
+        }
     }
 
     /// immutable read with reset

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,14 +1,14 @@
 //! Some emulator-related utils
 
-pub mod screen;
 pub mod clocks;
 pub mod events;
-pub mod smallnum;
 pub mod instantflag;
-pub use self::smallnum::*;
-pub use self::events::*;
+pub mod screen;
+pub mod smallnum;
 pub use self::clocks::*;
+pub use self::events::*;
 pub use self::instantflag::*;
+pub use self::smallnum::*;
 
 #[derive(Copy, Clone)]
 pub enum EmulationSpeed {

--- a/src/utils/screen.rs
+++ b/src/utils/screen.rs
@@ -1,6 +1,5 @@
-use zx::constants::*;
 use super::split_word;
-
+use zx::constants::*;
 
 /// Encode line number to read memory address
 pub fn bitmap_line_addr(line: usize) -> u16 {

--- a/src/z80/cpu.rs
+++ b/src/z80/cpu.rs
@@ -1,8 +1,8 @@
 //! Z80 CPU module
 
 use utils::*;
-use z80::*;
 use z80::opcodes::*;
+use z80::*;
 
 /// Z80 Processor struct
 pub struct Z80 {
@@ -90,7 +90,7 @@ impl Z80 {
                 execute_push_16(self, bus, RegName16::PC, Clocks(3));
                 self.regs.set_pc(0x0066);
                 self.regs.inc_r(1);
-                // 5 + 3 + 3 = 11 clocks
+            // 5 + 3 + 3 = 11 clocks
             } else if bus.int_active() && self.regs.get_iff1() {
                 // send to bus halt end message
                 if self.halted {
@@ -121,8 +121,8 @@ impl Z80 {
                     IntMode::IM2 => {
                         execute_push_16(self, bus, RegName16::PC, Clocks(3));
                         // build interrupt vector
-                        let addr = (((self.regs.get_i() as u16) << 8) & 0xFF00) |
-                                   (((bus.read_interrupt() as u16)) & 0x00FF);
+                        let addr = (((self.regs.get_i() as u16) << 8) & 0xFF00)
+                            | ((bus.read_interrupt() as u16) & 0x00FF);
                         let addr = bus.read_word(addr, Clocks(3));
                         self.regs.set_pc(addr);
                         bus.wait_internal(Clocks(7));
@@ -195,10 +195,6 @@ impl Z80 {
         // next cpu step
         bus.pc_callback(self.regs.get_pc());
         // return true if events happened
-        return if bus.instant_event() {
-            true
-        } else {
-            false
-        };
+        return if bus.instant_event() { true } else { false };
     }
 }

--- a/src/z80/mod.rs
+++ b/src/z80/mod.rs
@@ -1,14 +1,14 @@
 //! Module which contains all CPU-specific structures, functions, constants
 
-pub mod tables;
-mod common_types;
-mod registers;
 mod bus;
+mod common_types;
 mod cpu;
 pub mod opcodes;
+mod registers;
+pub mod tables;
 
 // Bring nested types and functions to current scope
-pub use self::common_types::*;
-pub use self::registers::*;
 pub use self::bus::*;
+pub use self::common_types::*;
 pub use self::cpu::*;
+pub use self::registers::*;

--- a/src/z80/opcodes/group_bits.rs
+++ b/src/z80/opcodes/group_bits.rs
@@ -1,7 +1,7 @@
 use super::*;
 use utils::*;
-use z80::*;
 use z80::tables::*;
+use z80::*;
 
 /// Instruction group which operatis with bits
 /// Includes rotations, setting, reseting, testing.

--- a/src/z80/opcodes/group_extended.rs
+++ b/src/z80/opcodes/group_extended.rs
@@ -1,7 +1,7 @@
 use super::*;
-use z80::*;
 use utils::*;
 use z80::tables::*;
+use z80::*;
 
 /// Extended instruction group (ED-prefixed)
 /// Operations are assorted.
@@ -55,8 +55,8 @@ pub fn execute_extended(cpu: &mut Z80, bus: &mut Z80Bus, opcode: Opcode) {
                         // SBC HL, rp[p]
                         U1::N0 => {
                             result = (hl as u32)
-                                         .wrapping_sub(operand as u32)
-                                         .wrapping_sub(prev_carry as u32);
+                                .wrapping_sub(operand as u32)
+                                .wrapping_sub(prev_carry as u32);
                             let lookup = lookup16_r12(hl, operand, result as u16);
                             flags |= OVERFLOW_SUB_TABLE[(lookup >> 4) as usize];
                             flags |= HALF_CARRY_SUB_TABLE[(lookup & 0x07) as usize];
@@ -65,8 +65,8 @@ pub fn execute_extended(cpu: &mut Z80, bus: &mut Z80Bus, opcode: Opcode) {
                         // ADC HL, rp[p]
                         U1::N1 => {
                             result = (hl as u32)
-                                         .wrapping_add(operand as u32)
-                                         .wrapping_add(prev_carry as u32);
+                                .wrapping_add(operand as u32)
+                                .wrapping_add(prev_carry as u32);
                             let lookup = lookup16_r12(hl, operand, result as u16);
                             flags |= OVERFLOW_ADD_TABLE[(lookup >> 4) as usize];
                             flags |= HALF_CARRY_ADD_TABLE[(lookup & 0x07) as usize];

--- a/src/z80/opcodes/group_nonprefixed.rs
+++ b/src/z80/opcodes/group_nonprefixed.rs
@@ -1,7 +1,7 @@
 use super::*;
-use z80::*;
 use utils::*;
 use z80::tables::*;
+use z80::*;
 
 /// normal execution group, can be modified with prefixes DD, FD, providing
 /// DD OPCODE [NN], FD OPCODE [NN] instruction group
@@ -430,8 +430,10 @@ pub fn execute_normal(cpu: &mut Z80, bus: &mut Z80Bus, opcode: Opcode, prefix: P
                 cpu.regs.inc_pc(1);
                 word_displacement(cpu.regs.get_reg_16(RegName16::HL.with_prefix(prefix)), d)
             };
-            cpu.regs.set_reg_8(RegName8::from_u3(opcode.y).unwrap(),
-                               bus.read(src_addr, Clocks(3)));
+            cpu.regs.set_reg_8(
+                RegName8::from_u3(opcode.y).unwrap(),
+                bus.read(src_addr, Clocks(3)),
+            );
             // Clocks:
             // HL: <4> + 3 = 7
             // XY+d: <[4] + 4> + [3 + 5] + 3 = 19
@@ -446,9 +448,11 @@ pub fn execute_normal(cpu: &mut Z80, bus: &mut Z80Bus, opcode: Opcode, prefix: P
                 cpu.regs.inc_pc(1);
                 word_displacement(cpu.regs.get_reg_16(RegName16::HL.with_prefix(prefix)), d)
             };
-            bus.write(dst_addr,
-                      cpu.regs.get_reg_8(RegName8::from_u3(opcode.z).unwrap()),
-                      Clocks(3));
+            bus.write(
+                dst_addr,
+                cpu.regs.get_reg_8(RegName8::from_u3(opcode.z).unwrap()),
+                Clocks(3),
+            );
             // Clocks:
             // HL: 4 + 3 = 7
             // XY+d: 4 + 4 + 3 + 5 + 3 = 19
@@ -476,9 +480,10 @@ pub fn execute_normal(cpu: &mut Z80, bus: &mut Z80Bus, opcode: Opcode, prefix: P
                     let d = bus.read(cpu.regs.get_pc(), Clocks(3)) as i8;
                     bus.wait_loop(cpu.regs.get_pc(), Clocks(5));
                     cpu.regs.inc_pc(1);
-                    let addr = word_displacement(cpu.regs
-                                                    .get_reg_16(RegName16::HL.with_prefix(prefix)),
-                                                 d);
+                    let addr = word_displacement(
+                        cpu.regs.get_reg_16(RegName16::HL.with_prefix(prefix)),
+                        d,
+                    );
                     bus.read(addr, Clocks(3))
                 }
             };
@@ -508,10 +513,12 @@ pub fn execute_normal(cpu: &mut Z80, bus: &mut Z80Bus, opcode: Opcode, prefix: P
                 // POP (AF/BC/DE/HL/IX/IY) ; pop 16 bit register featuring A
                 // [0b11pp0001]: C1; D1; E1; F1;
                 U1::N0 => {
-                    execute_pop_16(cpu,
-                                   bus,
-                                   RegName16::from_u2_af(opcode.p).with_prefix(prefix),
-                                   Clocks(3));
+                    execute_pop_16(
+                        cpu,
+                        bus,
+                        RegName16::from_u2_af(opcode.p).with_prefix(prefix),
+                        Clocks(3),
+                    );
                     // Clocks:
                     // [4] + 4 + 3 + 3 = 10 / 14
                 }
@@ -581,7 +588,8 @@ pub fn execute_normal(cpu: &mut Z80, bus: &mut Z80Bus, opcode: Opcode, prefix: P
                     let data = cpu.fetch_byte(bus, Clocks(3));
                     let acc = cpu.regs.get_acc();
                     // read from port A*256 + operand to Acc
-                    cpu.regs.set_acc(bus.read_io(((acc as u16) << 8) | (data as u16)));
+                    cpu.regs
+                        .set_acc(bus.read_io(((acc as u16) << 8) | (data as u16)));
                 }
                 // EX (SP), HL/IX/IY
                 // [0b11100011] : E3
@@ -646,10 +654,12 @@ pub fn execute_normal(cpu: &mut Z80, bus: &mut Z80Bus, opcode: Opcode, prefix: P
                 // [0b11pp0101] : C5; D5; E5; F5;
                 U1::N0 => {
                     bus.wait_no_mreq(cpu.regs.get_ir(), Clocks(1));
-                    execute_push_16(cpu,
-                                    bus,
-                                    RegName16::from_u2_af(opcode.p).with_prefix(prefix),
-                                    Clocks(3));
+                    execute_push_16(
+                        cpu,
+                        bus,
+                        RegName16::from_u2_af(opcode.p).with_prefix(prefix),
+                        Clocks(3),
+                    );
                 }
                 U1::N1 => {
                     match opcode.p {
@@ -692,7 +702,8 @@ pub fn execute_normal(cpu: &mut Z80, bus: &mut Z80Bus, opcode: Opcode, prefix: P
             bus.wait_no_mreq(cpu.regs.get_ir(), Clocks(1));
             execute_push_16(cpu, bus, RegName16::PC, Clocks(3));
             // CALL y*8
-            cpu.regs.set_reg_16(RegName16::PC, (opcode.y.as_byte() as u16) * 8);
+            cpu.regs
+                .set_reg_16(RegName16::PC, (opcode.y.as_byte() as u16) * 8);
             // 4 + 1 + 3 + 3 = 11
         }
     };

--- a/src/z80/opcodes/internal_alu.rs
+++ b/src/z80/opcodes/internal_alu.rs
@@ -1,6 +1,6 @@
-use z80::*;
 use utils::*;
 use z80::tables::*;
+use z80::*;
 
 /// 8-bit ALU operations
 pub fn execute_alu_8(cpu: &mut Z80, alu_code: U3, operand: u8) {
@@ -25,8 +25,8 @@ pub fn execute_alu_8(cpu: &mut Z80, alu_code: U3, operand: u8) {
         // ADC A, Operand
         U3::N1 => {
             let temp: u16 = (acc as u16)
-                                .wrapping_add(operand as u16)
-                                .wrapping_add(prev_carry as u16);
+                .wrapping_add(operand as u16)
+                .wrapping_add(prev_carry as u16);
             result = temp as u8;
             let lookup = lookup8_r12(acc, operand, temp as u8);
             flags |= OVERFLOW_ADD_TABLE[(lookup >> 4) as usize];
@@ -46,8 +46,8 @@ pub fn execute_alu_8(cpu: &mut Z80, alu_code: U3, operand: u8) {
         // SBC A, Operand; CP A, Operand
         U3::N3 => {
             let temp: u16 = (acc as u16)
-                                .wrapping_sub(operand as u16)
-                                .wrapping_sub(prev_carry as u16);
+                .wrapping_sub(operand as u16)
+                .wrapping_sub(prev_carry as u16);
             result = temp as u8;
             let lookup = lookup8_r12(acc, operand, temp as u8);
             flags |= OVERFLOW_SUB_TABLE[(lookup >> 4) as usize];

--- a/src/z80/opcodes/internal_block.rs
+++ b/src/z80/opcodes/internal_block.rs
@@ -1,7 +1,7 @@
 use super::*;
-use z80::*;
-use z80::tables::*;
 use utils::*;
+use z80::tables::*;
+use z80::*;
 
 /// ldi or ldd instruction
 pub fn execute_ldi_ldd(cpu: &mut Z80, bus: &mut Z80Bus, dir: BlockDir) {

--- a/src/z80/opcodes/internal_rot.rs
+++ b/src/z80/opcodes/internal_rot.rs
@@ -1,7 +1,7 @@
-use utils::*;
 use super::*;
-use z80::*;
+use utils::*;
 use z80::tables::*;
+use z80::*;
 
 /// Rotate operations (RLC, RRC, RL, RR, SLA, SRA, SLL, SRL)
 /// returns result (can be useful with DDCB/FDCB instructions)

--- a/src/z80/opcodes/internal_stack.rs
+++ b/src/z80/opcodes/internal_stack.rs
@@ -1,5 +1,5 @@
+use utils::{make_word, split_word, Clocks};
 use z80::*;
-use utils::{split_word, make_word, Clocks};
 
 /// Pushes 16 bit value to the stack. Clocks count using for each byte write
 pub fn execute_push_16(cpu: &mut Z80, bus: &mut Z80Bus, reg: RegName16, clk: Clocks) {

--- a/src/z80/opcodes/mod.rs
+++ b/src/z80/opcodes/mod.rs
@@ -1,20 +1,20 @@
 //! Module consist of function which represents different execution groups and some
 //! small related types
-mod types;
-mod internal_alu;
-mod internal_rot;
-mod internal_block;
-mod internal_stack;
-mod group_nonprefixed;
 mod group_bits;
 mod group_extended;
+mod group_nonprefixed;
+mod internal_alu;
+mod internal_block;
+mod internal_rot;
+mod internal_stack;
+mod types;
 
 // re-export all functions
-pub use self::types::*;
-pub use self::internal_alu::*;
-pub use self::internal_rot::*;
-pub use self::internal_block::*;
-pub use self::internal_stack::*;
-pub use self::group_nonprefixed::*;
 pub use self::group_bits::*;
 pub use self::group_extended::*;
+pub use self::group_nonprefixed::*;
+pub use self::internal_alu::*;
+pub use self::internal_block::*;
+pub use self::internal_rot::*;
+pub use self::internal_stack::*;
+pub use self::types::*;

--- a/src/z80/registers.rs
+++ b/src/z80/registers.rs
@@ -1,6 +1,6 @@
 //! Module which contains Z80 registers implementation
-use utils::*;
 use std::fmt;
+use utils::*;
 use z80::Prefix;
 
 // Flag register bits
@@ -41,7 +41,6 @@ impl Flag {
         }
     }
 }
-
 
 /// Conditions
 #[derive(Clone, Copy)]
@@ -103,25 +102,19 @@ impl RegName8 {
     /// Modificates 8-bit register with prefix
     pub fn with_prefix(self, pref: Prefix) -> Self {
         match self {
-            reg @ RegName8::H | reg @ RegName8::L => {
-                match pref {
-                    Prefix::DD => {
-                        match reg {
-                            RegName8::H => RegName8::IXH,
-                            RegName8::L => RegName8::IXL,
-                            _ => reg,
-                        }
-                    }
-                    Prefix::FD => {
-                        match reg {
-                            RegName8::H => RegName8::IYH,
-                            RegName8::L => RegName8::IYL,
-                            _ => reg,
-                        }
-                    }
+            reg @ RegName8::H | reg @ RegName8::L => match pref {
+                Prefix::DD => match reg {
+                    RegName8::H => RegName8::IXH,
+                    RegName8::L => RegName8::IXL,
                     _ => reg,
-                }
-            }
+                },
+                Prefix::FD => match reg {
+                    RegName8::H => RegName8::IYH,
+                    RegName8::L => RegName8::IYL,
+                    _ => reg,
+                },
+                _ => reg,
+            },
             _ => self,
         }
     }
@@ -158,13 +151,11 @@ impl RegName16 {
     // Modificates 16-bit register with prefix
     pub fn with_prefix(self, pref: Prefix) -> Self {
         match self {
-            RegName16::HL => {
-                match pref {
-                    Prefix::DD => RegName16::IX,
-                    Prefix::FD => RegName16::IY,
-                    _ => self,
-                }
-            }
+            RegName16::HL => match pref {
+                Prefix::DD => RegName16::IX,
+                Prefix::FD => RegName16::IY,
+                _ => self,
+            },
             _ => self,
         }
     }

--- a/src/z80/tables/mod.rs
+++ b/src/z80/tables/mod.rs
@@ -54,31 +54,30 @@ const PARITY_BIT: [u8; 256] = [
 	1, 0, 0, 1, 0, 1, 1, 0, 0, 1, 1, 0, 1, 0, 0, 1,
 ];
 
-
 // Generated table of parity flag setting
-lazy_static!{
+lazy_static! {
     pub static ref PARITY_TABLE: [u8; 256] = {
         let mut arr = [0u8; 256];
         for (n, x) in arr.iter_mut().enumerate() {
             *x = PARITY_BIT[n] * FLAG_PV;
-        };
+        }
         arr
     };
 }
 
 // Generated table of F3 and F5 flags
-lazy_static!{
+lazy_static! {
     pub static ref F3F5_TABLE: [u8; 256] = {
         let mut arr = [0u8; 256];
         for (n, x) in arr.iter_mut().enumerate() {
             *x = (n as u8) & (FLAG_F3 | FLAG_F5);
-        };
+        }
         arr
     };
 }
 
 // Generated table of F3,F5,Z,S flags
-lazy_static!{
+lazy_static! {
     pub static ref SZF3F5_TABLE: [u8; 256] = {
         let mut arr = [0u8; 256];
         for (n, x) in arr.iter_mut().enumerate() {
@@ -86,13 +85,13 @@ lazy_static!{
             if n == 0 {
                 *x |= FLAG_ZERO;
             };
-        };
+        }
         arr
     };
 }
 
 // Generated table of F3,F5,Z,S flags
-lazy_static!{
+lazy_static! {
     pub static ref SZPF3F5_TABLE: [u8; 256] = {
         let mut arr = [0u8; 256];
         for (n, x) in arr.iter_mut().enumerate() {
@@ -101,7 +100,7 @@ lazy_static!{
             if n == 0 {
                 *x |= FLAG_ZERO;
             };
-        };
+        }
         arr
     };
 }

--- a/src/zx/joy/kempston.rs
+++ b/src/zx/joy/kempston.rs
@@ -15,9 +15,7 @@ pub struct KempstonJoy {
 impl KempstonJoy {
     /// Constructs new Kemoston
     pub fn new() -> Self {
-        KempstonJoy {
-            state: 0x00,
-        }
+        KempstonJoy { state: 0x00 }
     }
     /// Simulates key press/release
     pub fn key(&mut self, key: KempstonKey, state: bool) {

--- a/src/zx/machine/mod.rs
+++ b/src/zx/machine/mod.rs
@@ -2,9 +2,9 @@
 
 // Allow outer modules to use ZXSpecs struct, but not construct
 mod specs;
+pub use self::specs::ZXSpecs;
 use self::specs::ZXSpecsBuilder;
 use utils::Clocks;
-pub use self::specs::ZXSpecs;
 
 lazy_static! {
     /// ZX Spectrum 48K Specs
@@ -57,13 +57,14 @@ impl ZXMachine {
     /// Returns contention during specified time
     pub fn contention_clocks(self, clocks: Clocks) -> Clocks {
         let specs = self.specs();
-        if (clocks.count() < (specs.clocks_first_pixel - 1)) ||
-           (clocks.count() >=
-            (specs.clocks_first_pixel - 1) + specs.lines_screen * specs.clocks_line) {
+        if (clocks.count() < (specs.clocks_first_pixel - 1))
+            || (clocks.count()
+                >= (specs.clocks_first_pixel - 1) + specs.lines_screen * specs.clocks_line)
+        {
             return Clocks(0);
         }
-        let clocks_trough_line = (clocks.count() - (specs.clocks_first_pixel - 1)) %
-                                 specs.clocks_line;
+        let clocks_trough_line =
+            (clocks.count() - (specs.clocks_first_pixel - 1)) % specs.clocks_line;
         if clocks_trough_line >= specs.clocks_screen_row {
             return Clocks(0);
         }
@@ -83,9 +84,7 @@ impl ZXMachine {
     /// Returns contention status of bank
     pub fn bank_is_contended(self, page: usize) -> bool {
         match self {
-            ZXMachine::Sinclair48K => {
-                page == 0
-            }
+            ZXMachine::Sinclair48K => page == 0,
             ZXMachine::Sinclair128K => {
                 let contended_pages = [1, 3, 5, 7];
                 contended_pages.iter().any(|&x| x == page)

--- a/src/zx/machine/specs.rs
+++ b/src/zx/machine/specs.rs
@@ -76,12 +76,14 @@ impl ZXSpecsBuilder {
     }
     /// Builds new ZXSpecs
     pub fn build(mut self) -> ZXSpecs {
-        self.specs.clocks_frame = (self.specs.lines_all + self.specs.lines_vsync) *
-                                  self.specs.clocks_line;
+        self.specs.clocks_frame =
+            (self.specs.lines_all + self.specs.lines_vsync) * self.specs.clocks_line;
         // 4*4 is 4 border columns * 4 clocks per column
-        self.specs.clocks_line_base.push(self.specs.clocks_first_pixel -
-                                         self.specs.lines_top_border * self.specs.clocks_line -
-                                         BORDER_COLS * 4);
+        self.specs.clocks_line_base.push(
+            self.specs.clocks_first_pixel
+                - self.specs.lines_top_border * self.specs.clocks_line
+                - BORDER_COLS * 4,
+        );
         // + 1 because TStates in calculations may be > frame length (CHECK)
         let lines_count = self.specs.lines_all + 1;
         for _ in 1..lines_count {
@@ -89,10 +91,10 @@ impl ZXSpecsBuilder {
             let line_clocks = self.specs.clocks_line;
             self.specs.clocks_line_base.push(last + line_clocks);
         }
-        self.specs.clocks_ula_read_origin = self.specs.clocks_first_pixel +
-                                            self.specs.clocks_ula_read_shift;
-        self.specs.clocks_ula_contention_origin = self.specs.clocks_first_pixel -
-                                                  self.specs.contention_offset;
+        self.specs.clocks_ula_read_origin =
+            self.specs.clocks_first_pixel + self.specs.clocks_ula_read_shift;
+        self.specs.clocks_ula_contention_origin =
+            self.specs.clocks_first_pixel - self.specs.contention_offset;
         self.specs
     }
     /// Changes CPU frequency
@@ -101,12 +103,13 @@ impl ZXSpecsBuilder {
         self
     }
     /// Changes Clocks per left border, screen render, left border and retrace
-    pub fn clocks_row(mut self,
-                      lborder: usize,
-                      screen: usize,
-                      rborder: usize,
-                      retrace: usize)
-                      -> Self {
+    pub fn clocks_row(
+        mut self,
+        lborder: usize,
+        screen: usize,
+        rborder: usize,
+        retrace: usize,
+    ) -> Self {
         self.specs.clocks_left_border = lborder;
         self.specs.clocks_screen_row = screen;
         self.specs.clocks_right_border = rborder;

--- a/src/zx/mod.rs
+++ b/src/zx/mod.rs
@@ -1,21 +1,21 @@
 //! Module with ZX Spectrum related things
 //! One of core platform-independent modules
-pub mod memory;
 pub mod controller;
+pub mod memory;
 pub mod screen;
 pub mod keys;
-pub mod tape;
-pub mod machine;
 pub mod constants;
+pub mod joy;
+pub mod machine;
 pub mod roms;
 pub mod sound;
-pub mod joy;
+pub mod tape;
 
 // re-export most of things
 // TODO: in-deep rewiew re-exports recursively
 pub use self::controller::ZXController;
-pub use self::machine::{ZXMachine, ZXSpecs};
-pub use self::memory::{ZXMemory, RomType, RamType};
-pub use self::screen::*;
 pub use self::keys::*;
+pub use self::machine::{ZXMachine, ZXSpecs};
+pub use self::memory::{RamType, RomType, ZXMemory};
+pub use self::screen::*;
 pub use self::tape::ZXTape;

--- a/src/zx/screen/border.rs
+++ b/src/zx/screen/border.rs
@@ -1,8 +1,8 @@
 //! Contains ZXSpectrum border implementation
+use super::colors::*;
 use utils::Clocks;
 use zx::constants::*;
 use zx::machine::*;
-use super::colors::*;
 
 /// Internal struct, which contains information about beam position and color
 #[derive(Clone, Copy)]
@@ -64,10 +64,10 @@ impl ZXBorder {
         let specs = self.machine.specs();
         // begining of the first line (first pixel timing minus border lines
         // minus left border columns)
-        let clocks_origin = specs.clocks_first_pixel -
-                            8 * BORDER_ROWS * specs.clocks_line as usize -
-                            BORDER_COLS * CLOCKS_PER_COL +
-                            specs.clocks_ula_beam_shift;
+        let clocks_origin = specs.clocks_first_pixel
+            - 8 * BORDER_ROWS * specs.clocks_line as usize
+            - BORDER_COLS * CLOCKS_PER_COL
+            + specs.clocks_ula_beam_shift;
         // return first pixel pos
         if clocks.count() < clocks_origin {
             return (0, 0, false);

--- a/src/zx/screen/canvas.rs
+++ b/src/zx/screen/canvas.rs
@@ -1,10 +1,10 @@
 //! Module describes ZX Spectrum screen
 //! *block* - is 8x1 pxels stripe.
-use utils::*;
 use utils::screen::*;
+use utils::*;
 use zx::constants::*;
-use zx::screen::colors::*;
 use zx::machine::ZXMachine;
+use zx::screen::colors::*;
 
 // size of screen buffer in bytes
 const BUFFER_LENGTH: usize = CANVAS_HEIGHT * CANVAS_WIDTH * BYTES_PER_PIXEL;
@@ -65,8 +65,8 @@ impl BlocksCount {
     pub fn passed_from(&self, prev: &BlocksCount) -> usize {
         if self.lines < prev.lines {
             ATTR_COLS - prev.columns
-            //self.lines * ATTR_COLS + self.columns
-        } else  if self.lines == prev.lines {
+        //self.lines * ATTR_COLS + self.columns
+        } else if self.lines == prev.lines {
             // if positions on the same line => just use difference in columns.
             self.columns - prev.columns
         } else {
@@ -112,12 +112,12 @@ impl ZXCanvas {
             banks: [
                 ScreenBank {
                     attributes: Box::new([ZXAttribute::from_byte(0); ATTR_COLS * ATTR_ROWS]),
-                    bitmap:  Box::new([0; ATTR_COLS * CANVAS_HEIGHT]),
+                    bitmap: Box::new([0; ATTR_COLS * CANVAS_HEIGHT]),
                 },
                 ScreenBank {
-                    attributes:  Box::new([ZXAttribute::from_byte(0); ATTR_COLS * ATTR_ROWS]),
-                    bitmap:  Box::new([0; ATTR_COLS * CANVAS_HEIGHT]),
-                }
+                    attributes: Box::new([ZXAttribute::from_byte(0); ATTR_COLS * ATTR_ROWS]),
+                    bitmap: Box::new([0; ATTR_COLS * CANVAS_HEIGHT]),
+                },
             ],
             active_bank: 0,
             next_bank: 0,
@@ -168,8 +168,9 @@ impl ZXCanvas {
                 for pixel in 0..8 {
                     // from most significant bit
                     let state = ((bitmap << pixel) & 0x80) != 0;
-                    let color = self.palette.get_rgba(attr.active_color(state, self.flash),
-                                                      attr.brightness);
+                    let color = self
+                        .palette
+                        .get_rgba(attr.active_color(state, self.flash), attr.brightness);
                     let index = (block * 8 + pixel) * BYTES_PER_PIXEL;
                     self.buffer[index..index + BYTES_PER_PIXEL].clone_from_slice(color);
                 }

--- a/src/zx/screen/mod.rs
+++ b/src/zx/screen/mod.rs
@@ -1,5 +1,5 @@
 //! Module contains all screen-rendering platform-independent
 //! types and functions
-pub mod colors;
-pub mod canvas;
 pub mod border;
+pub mod canvas;
+pub mod colors;

--- a/src/zx/sound/ay.rs
+++ b/src/zx/sound/ay.rs
@@ -1,7 +1,7 @@
+use ayumi::{Ayumi, ChipType, ToneChannel};
 use utils::make_word;
+use zx::sound::sample::{SampleGenerator, SoundSample};
 use zx::sound::SAMPLE_RATE;
-use zx::sound::sample::{SoundSample, SampleGenerator};
-use ayumi::{Ayumi, ToneChannel, ChipType};
 
 /// AY chip runs on the same frequency on 128K, 2+, 3+
 const AY_FREQ: f64 = 1773400.0;
@@ -37,15 +37,9 @@ impl ZXAyChip {
     /// Changes AY mode
     pub fn mode(&mut self, mode: ZXAYMode) {
         let (a, b, c) = match mode {
-            ZXAYMode::Mono => {
-                (0.5, 0.5, 0.5)
-            }
-            ZXAYMode::ABC => {
-                (0.0, 0.5, 1.0)
-            }
-            ZXAYMode::ACB => {
-                (0.0, 1.0, 0.5)
-            }
+            ZXAYMode::Mono => (0.5, 0.5, 0.5),
+            ZXAYMode::ABC => (0.0, 0.5, 1.0),
+            ZXAYMode::ACB => (0.0, 1.0, 0.5),
         };
         self.ay.tone(ToneChannel::A).pan(a, true);
         self.ay.tone(ToneChannel::B).pan(b, true);
@@ -63,17 +57,17 @@ impl ZXAyChip {
         self.regs[reg] = data;
         match self.current_reg {
             // Channel A tone period
-            0 ... 1 => {
+            0...1 => {
                 let word = make_word(self.regs[1] & 0x0F, self.regs[0]);
                 self.ay.tone(ToneChannel::A).period(word as i32);
             }
             // Channel B tone period
-            2 ... 3 => {
+            2...3 => {
                 let word = make_word(self.regs[3] & 0x0F, self.regs[2]);
                 self.ay.tone(ToneChannel::B).period(word as i32);
             }
             // Channel C tone period
-            4 ... 5 => {
+            4...5 => {
                 let word = make_word(self.regs[5] & 0x0F, self.regs[4]);
                 self.ay.tone(ToneChannel::C).period(word as i32);
             }
@@ -82,30 +76,30 @@ impl ZXAyChip {
                 self.ay.noise().period((self.regs[6] & 0x1F) as i32);
             }
             // Mixer Controls
-            7 ... 10 => {
-                self.ay.tone(ToneChannel::A)
-                       .mixer((self.regs[7] & 0x01) != 0,
-                              (self.regs[7] & 0x08) != 0,
-                              (self.regs[8] & 0x10) != 0);
-                self.ay.tone(ToneChannel::B)
-                       .mixer((self.regs[7] & 0x02) != 0,
-                              (self.regs[7] & 0x10) != 0,
-                              (self.regs[9] & 0x10) != 0);
-                self.ay.tone(ToneChannel::C)
-                       .mixer((self.regs[7] & 0x04) != 0,
-                              (self.regs[7] & 0x20) != 0,
-                              (self.regs[10] & 0x10) != 0);
+            7...10 => {
+                self.ay.tone(ToneChannel::A).mixer(
+                    (self.regs[7] & 0x01) != 0,
+                    (self.regs[7] & 0x08) != 0,
+                    (self.regs[8] & 0x10) != 0,
+                );
+                self.ay.tone(ToneChannel::B).mixer(
+                    (self.regs[7] & 0x02) != 0,
+                    (self.regs[7] & 0x10) != 0,
+                    (self.regs[9] & 0x10) != 0,
+                );
+                self.ay.tone(ToneChannel::C).mixer(
+                    (self.regs[7] & 0x04) != 0,
+                    (self.regs[7] & 0x20) != 0,
+                    (self.regs[10] & 0x10) != 0,
+                );
                 if self.current_reg > 7 {
-                    self.ay.tone(ToneChannel::A)
-                           .volume(self.regs[8] & 0x0F);
-                    self.ay.tone(ToneChannel::B)
-                           .volume(self.regs[9] & 0x0F);
-                    self.ay.tone(ToneChannel::C)
-                           .volume(self.regs[10] & 0x0F);
+                    self.ay.tone(ToneChannel::A).volume(self.regs[8] & 0x0F);
+                    self.ay.tone(ToneChannel::B).volume(self.regs[9] & 0x0F);
+                    self.ay.tone(ToneChannel::C).volume(self.regs[10] & 0x0F);
                 }
             }
             // Envelope period
-            11 ... 12 => {
+            11...12 => {
                 let word = make_word(self.regs[12] & 0x0F, self.regs[11]);
                 self.ay.envelope().period(word as i32);
             }

--- a/src/zx/sound/mixer.rs
+++ b/src/zx/sound/mixer.rs
@@ -1,9 +1,9 @@
 //! Module implemets zx spectrum audio devices mixer
 use std::collections::VecDeque;
-use zx::sound::{SAMPLES, samples_from_time};
-use zx::sound::sample::{SoundSample, SampleGenerator};
+use zx::sound::ay::{ZXAYMode, ZXAyChip};
 use zx::sound::beeper::ZXBeeper;
-use zx::sound::ay::{ZXAyChip, ZXAYMode};
+use zx::sound::sample::{SampleGenerator, SoundSample};
+use zx::sound::{samples_from_time, SAMPLES};
 
 /// Main sound mixer.
 pub struct ZXMixer {
@@ -85,7 +85,7 @@ impl ZXMixer {
     fn gen_sample(&mut self) -> SoundSample<f32> {
         let mut master_float = if self.use_beeper {
             self.beeper.gen_sample()
-        }  else {
+        } else {
             SoundSample::new(0.0, 0.0)
         };
         // prevent AY sound generation if disabled [it is pretty long process]

--- a/src/zx/sound/mod.rs
+++ b/src/zx/sound/mod.rs
@@ -1,6 +1,6 @@
 //! Module implements emulation of sound chip AY, Spectrum Beeper and Mixer
-pub mod beeper;
 pub mod ay;
+pub mod beeper;
 pub mod mixer;
 pub mod sample;
 

--- a/src/zx/sound/sample.rs
+++ b/src/zx/sound/sample.rs
@@ -1,7 +1,7 @@
 use std::i16;
-use std::ops::{MulAssign, Mul, Add, Sub};
+use std::ops::{Add, Mul, MulAssign, Sub};
 /// Raw Sample can be only f64 or i16
-pub trait RawSample : Clone + Copy + MulAssign + Mul + Add + Sub {}
+pub trait RawSample: Clone + Copy + MulAssign + Mul + Add + Sub {}
 impl RawSample for f64 {}
 impl RawSample for f32 {}
 impl RawSample for i16 {}
@@ -16,12 +16,18 @@ const ERROR_SIZE: u16 = 100;
 // - `normalize` - to fit sample in 0..1 range
 // - `into_i16` - to transform sa,ple to i16 sample
 #[derive(Clone, Copy)]
-pub struct SoundSample<T> where T: RawSample {
+pub struct SoundSample<T>
+where
+    T: RawSample,
+{
     pub left: T,
     pub right: T,
 }
 
-impl<T> SoundSample<T> where T: RawSample {
+impl<T> SoundSample<T>
+where
+    T: RawSample,
+{
     /// Returns new sample
     pub fn new(left: T, right: T) -> SoundSample<T> {
         SoundSample {
@@ -95,7 +101,10 @@ impl SoundSample<f64> {
 }
 
 /// Trait which signals that structure can generate SoundSamples
-pub trait SampleGenerator<T> where T: RawSample {
+pub trait SampleGenerator<T>
+where
+    T: RawSample,
+{
     /// Returns generated sound sample of `SoundSample<T>` type
     fn gen_sample(&mut self) -> SoundSample<T>;
 }

--- a/src/zx/tape/tap.rs
+++ b/src/zx/tape/tap.rs
@@ -158,7 +158,6 @@ impl ZXTape for Tap {
         } else {
             return InsertResult::Err("Can't open TAP file");
         }
-
     }
 
     /// makes internal state change based on clocks count


### PR DESCRIPTION
Rustfmt simplifies writing code as formating can be fully automatic. Especially it helps in separating long lines when chaining calls, long lists of arguments; also sorted import lists look better as imports from the same module will be sorted nearby.

Applied formatting here.