### PR TITLE
Fix deprecation warnings introduced in Rust 1.37

### DIFF
--- a/src/app/rustzx.rs
+++ b/src/app/rustzx.rs
@@ -35,9 +35,9 @@ pub struct RustzxApp {
     /// main emulator object
     emulator: Emulator,
     /// Sound rendering in a separate thread
-    snd: Option<Box<SoundDevice>>,
-    video: Box<VideoDevice>,
-    events: Box<EventDevice>,
+    snd: Option<Box<dyn SoundDevice>>,
+    video: Box<dyn VideoDevice>,
+    events: Box<dyn EventDevice>,
     tex_border: TextureInfo,
     tex_canvas: TextureInfo,
     settings: RustzxSettings,
@@ -46,7 +46,7 @@ pub struct RustzxApp {
 impl RustzxApp {
     /// Starts application itself
     pub fn from_config(settings: RustzxSettings) -> RustzxApp {
-        let snd: Option<Box<SoundDevice>> = if settings.sound_enabled {
+        let snd: Option<Box<dyn SoundDevice>> = if settings.sound_enabled {
             Some(Box::new(SoundSdl::new(&settings)))
         } else {
             None

--- a/src/z80/cpu.rs
+++ b/src/z80/cpu.rs
@@ -31,7 +31,7 @@ impl Z80 {
 
     /// Reads byte from memory and increments PC
     #[inline]
-    pub fn fetch_byte(&mut self, bus: &mut Z80Bus, clk: Clocks) -> u8 {
+    pub fn fetch_byte(&mut self, bus: &mut dyn Z80Bus, clk: Clocks) -> u8 {
         let addr = self.regs.get_pc();
         self.regs.inc_pc(1);
         bus.read(addr, clk)
@@ -39,7 +39,7 @@ impl Z80 {
 
     /// Reads word from memory and increments PC twice
     #[inline]
-    pub fn fetch_word(&mut self, bus: &mut Z80Bus, clk: Clocks) -> u16 {
+    pub fn fetch_word(&mut self, bus: &mut dyn Z80Bus, clk: Clocks) -> u16 {
         let (hi_addr, lo_addr);
         lo_addr = self.regs.get_pc();
         let lo = bus.read(lo_addr, clk);
@@ -71,7 +71,7 @@ impl Z80 {
     /// Main emulation step function
     /// return `false` if execution can be continued or true if last event must be executed
     /// instantly
-    pub fn emulate(&mut self, bus: &mut Z80Bus) -> bool {
+    pub fn emulate(&mut self, bus: &mut dyn Z80Bus) -> bool {
         // check interrupts
         if !self.skip_interrupt {
             // at first check nmi

--- a/src/z80/opcodes/group_bits.rs
+++ b/src/z80/opcodes/group_bits.rs
@@ -7,7 +7,7 @@ use z80::*;
 /// Includes rotations, setting, reseting, testing.
 /// covers CB, DDCB and FDCB execution group
 /// `prefix` param stands for first byte in double-prefixed instructions
-pub fn execute_bits(cpu: &mut Z80, bus: &mut Z80Bus, prefix: Prefix) {
+pub fn execute_bits(cpu: &mut Z80, bus: &mut dyn Z80Bus, prefix: Prefix) {
     let (opcode, operand) = if prefix == Prefix::None {
         // normal opcode fetch
         let tmp_opcode = Opcode::from_byte(cpu.fetch_byte(bus, Clocks(4)));

--- a/src/z80/opcodes/group_extended.rs
+++ b/src/z80/opcodes/group_extended.rs
@@ -5,7 +5,7 @@ use z80::*;
 
 /// Extended instruction group (ED-prefixed)
 /// Operations are assorted.
-pub fn execute_extended(cpu: &mut Z80, bus: &mut Z80Bus, opcode: Opcode) {
+pub fn execute_extended(cpu: &mut Z80, bus: &mut dyn Z80Bus, opcode: Opcode) {
     match opcode.x {
         U2::N0 | U2::N3 => {
             // Nothing. Just nothung. Invalid opcodes.

--- a/src/z80/opcodes/group_nonprefixed.rs
+++ b/src/z80/opcodes/group_nonprefixed.rs
@@ -11,7 +11,7 @@ use z80::*;
 ///
 /// DAA algorithm
 /// [link](http://www.worldofspectrum.org/faq/reference/z80reference.htm#DAA)
-pub fn execute_normal(cpu: &mut Z80, bus: &mut Z80Bus, opcode: Opcode, prefix: Prefix) {
+pub fn execute_normal(cpu: &mut Z80, bus: &mut dyn Z80Bus, opcode: Opcode, prefix: Prefix) {
     // 2 first bits of opcode
     match opcode.x {
         // ---------------------------------

--- a/src/z80/opcodes/internal_block.rs
+++ b/src/z80/opcodes/internal_block.rs
@@ -4,7 +4,7 @@ use z80::tables::*;
 use z80::*;
 
 /// ldi or ldd instruction
-pub fn execute_ldi_ldd(cpu: &mut Z80, bus: &mut Z80Bus, dir: BlockDir) {
+pub fn execute_ldi_ldd(cpu: &mut Z80, bus: &mut dyn Z80Bus, dir: BlockDir) {
     // read (HL)
     let src = bus.read(cpu.regs.get_hl(), Clocks(3));
     let bc = cpu.regs.dec_reg_16(RegName16::BC, 1);
@@ -37,7 +37,7 @@ pub fn execute_ldi_ldd(cpu: &mut Z80, bus: &mut Z80Bus, dir: BlockDir) {
 }
 
 /// cpi or cpd instruction
-pub fn execute_cpi_cpd(cpu: &mut Z80, bus: &mut Z80Bus, dir: BlockDir) -> bool {
+pub fn execute_cpi_cpd(cpu: &mut Z80, bus: &mut dyn Z80Bus, dir: BlockDir) -> bool {
     // read (HL)
     let src = bus.read(cpu.regs.get_hl(), Clocks(3));
     bus.wait_loop(cpu.regs.get_hl(), Clocks(5));
@@ -73,7 +73,7 @@ pub fn execute_cpi_cpd(cpu: &mut Z80, bus: &mut Z80Bus, dir: BlockDir) -> bool {
 }
 
 /// ini or ind instruction
-pub fn execute_ini_ind(cpu: &mut Z80, bus: &mut Z80Bus, dir: BlockDir) {
+pub fn execute_ini_ind(cpu: &mut Z80, bus: &mut dyn Z80Bus, dir: BlockDir) {
     bus.wait_no_mreq(cpu.regs.get_ir(), Clocks(1));
     // get from port and write to memory
     let src = bus.read_io(cpu.regs.get_bc());
@@ -104,7 +104,7 @@ pub fn execute_ini_ind(cpu: &mut Z80, bus: &mut Z80Bus, dir: BlockDir) {
 }
 
 /// outi or outd instruction
-pub fn execute_outi_outd(cpu: &mut Z80, bus: &mut Z80Bus, dir: BlockDir) {
+pub fn execute_outi_outd(cpu: &mut Z80, bus: &mut dyn Z80Bus, dir: BlockDir) {
     bus.wait_no_mreq(cpu.regs.get_ir(), Clocks(1));
     // get input data
     let src = bus.read(cpu.regs.get_hl(), Clocks(3));

--- a/src/z80/opcodes/internal_rot.rs
+++ b/src/z80/opcodes/internal_rot.rs
@@ -5,7 +5,7 @@ use z80::*;
 
 /// Rotate operations (RLC, RRC, RL, RR, SLA, SRA, SLL, SRL)
 /// returns result (can be useful with DDCB/FDCB instructions)
-pub fn execute_rot(cpu: &mut Z80, bus: &mut Z80Bus, rot_code: U3, operand: BitOperand8) -> u8 {
+pub fn execute_rot(cpu: &mut Z80, bus: &mut dyn Z80Bus, rot_code: U3, operand: BitOperand8) -> u8 {
     // get byte which will be rotated
     let mut data = match operand {
         BitOperand8::Indirect(addr) => {

--- a/src/z80/opcodes/internal_stack.rs
+++ b/src/z80/opcodes/internal_stack.rs
@@ -2,7 +2,7 @@ use utils::{make_word, split_word, Clocks};
 use z80::*;
 
 /// Pushes 16 bit value to the stack. Clocks count using for each byte write
-pub fn execute_push_16(cpu: &mut Z80, bus: &mut Z80Bus, reg: RegName16, clk: Clocks) {
+pub fn execute_push_16(cpu: &mut Z80, bus: &mut dyn Z80Bus, reg: RegName16, clk: Clocks) {
     // h then l
     let (h, l) = split_word(cpu.regs.get_reg_16(reg));
     bus.write(cpu.regs.dec_sp(1), h, clk);
@@ -10,7 +10,7 @@ pub fn execute_push_16(cpu: &mut Z80, bus: &mut Z80Bus, reg: RegName16, clk: Clo
 }
 
 /// Pops 16 bit value from the stack. Clocks count using for each byte read
-pub fn execute_pop_16(cpu: &mut Z80, bus: &mut Z80Bus, reg: RegName16, clk: Clocks) {
+pub fn execute_pop_16(cpu: &mut Z80, bus: &mut dyn Z80Bus, reg: RegName16, clk: Clocks) {
     let (h, l);
     l = bus.read(cpu.regs.get_sp(), clk);
     cpu.regs.inc_sp(1);

--- a/src/zx/controller.rs
+++ b/src/zx/controller.rs
@@ -29,7 +29,7 @@ pub struct ZXController {
     pub machine: ZXMachine,
     pub memory: ZXMemory,
     pub canvas: ZXCanvas,
-    pub tape: Box<ZXTape>,
+    pub tape: Box<dyn ZXTape>,
     pub border: ZXBorder,
     pub kempston: Option<KempstonJoy>,
     //pub beeper: ZXBeeper,

--- a/src/zx/screen/canvas.rs
+++ b/src/zx/screen/canvas.rs
@@ -196,13 +196,13 @@ impl ZXCanvas {
         if let Some(bank) = self.local_bank(bank) {
             match rel_addr {
                 // change bitmap
-                0...BITMAP_MAX_REL => {
+                0..=BITMAP_MAX_REL => {
                     let line = bitmap_line_rel(rel_addr);
                     let col = bitmap_col_rel(rel_addr);
                     self.banks[bank].bitmap[line * ATTR_COLS + col] = data;
                 }
                 // change attribute
-                ATTR_BASE_REL...ATTR_MAX_REL => {
+                ATTR_BASE_REL..=ATTR_MAX_REL => {
                     let row = attr_row_rel(rel_addr);
                     let col = attr_col_rel(rel_addr);
                     self.banks[bank].attributes[row * ATTR_COLS + col] =

--- a/src/zx/sound/ay.rs
+++ b/src/zx/sound/ay.rs
@@ -47,7 +47,7 @@ impl ZXAyChip {
     }
     /// Selects active AY register to write
     pub fn select_reg(&mut self, reg: u8) {
-        // AY chip have only 16 regs [0...15]
+        // AY chip have only 16 regs [0..=15]
         self.current_reg = (reg & 0x0F) as usize;
     }
 
@@ -57,17 +57,17 @@ impl ZXAyChip {
         self.regs[reg] = data;
         match self.current_reg {
             // Channel A tone period
-            0...1 => {
+            0..=1 => {
                 let word = make_word(self.regs[1] & 0x0F, self.regs[0]);
                 self.ay.tone(ToneChannel::A).period(word as i32);
             }
             // Channel B tone period
-            2...3 => {
+            2..=3 => {
                 let word = make_word(self.regs[3] & 0x0F, self.regs[2]);
                 self.ay.tone(ToneChannel::B).period(word as i32);
             }
             // Channel C tone period
-            4...5 => {
+            4..=5 => {
                 let word = make_word(self.regs[5] & 0x0F, self.regs[4]);
                 self.ay.tone(ToneChannel::C).period(word as i32);
             }
@@ -76,7 +76,7 @@ impl ZXAyChip {
                 self.ay.noise().period((self.regs[6] & 0x1F) as i32);
             }
             // Mixer Controls
-            7...10 => {
+            7..=10 => {
                 self.ay.tone(ToneChannel::A).mixer(
                     (self.regs[7] & 0x01) != 0,
                     (self.regs[7] & 0x08) != 0,
@@ -99,7 +99,7 @@ impl ZXAyChip {
                 }
             }
             // Envelope period
-            11...12 => {
+            11..=12 => {
                 let word = make_word(self.regs[12] & 0x0F, self.regs[11]);
                 self.ay.envelope().period(word as i32);
             }


### PR DESCRIPTION
Rust 1.37 introduced new deprecations:

- trait objects without `dyn` keyword syntax

  ```
  warning: trait objects without an explicit `dyn` are deprecated
    --> src/app/rustzx.rs:38:21
     |
  38 |     snd: Option<Box<SoundDevice>>,
     |                     ^^^^^^^^^^^ help: use `dyn`: `dyn SoundDevice`
     |
     = note: #[warn(bare_trait_objects)] on by default
  ```

- `...` for range literals

  ```
  warning: `...` range patterns are deprecated
    --> src/zx/sound/ay.rs:60:14
     |
  60 |             0...1 => {
     |              ^^^ help: use `..=` for an inclusive range
  ```

Updated both to new syntax.